### PR TITLE
Update formula for kiek 1.5.0

### DIFF
--- a/Formula/kiek.rb
+++ b/Formula/kiek.rb
@@ -1,14 +1,14 @@
 class Kiek < Formula
-  version '1.4.0'
+  version '1.5.0'
   desc "kiek helps you to look into Kafka topics."
   homepage "https://github.com/wulf-data-engineering/kiek"
 
   if OS.mac?
       url "https://github.com/wulf-data-engineering/kiek/releases/download/v#{version}/kiek-aarch64-apple-darwin.tar.gz"
-      sha256 "7662f3114e9d3c2dc0adad2319b029ad7e1e2aff0709154bb155d4c7bbbeef74"
+      sha256 "66244019e70ca3f92ffe5d00abdefff967c4f7e3785a3a391300caf6113fc52e"
   elsif OS.linux?
       url "https://github.com/wulf-data-engineering/kiek/releases/download/v#{version}/kiek-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "7636898bf03ddb6fb4b46bc5edcb72c5edc20547c45d94be9a1c64987067ca13"
+      sha256 "4aeb0cc9e1530106edc7107ab1cc5732c7dd2bdfc6f84a1eed17b473360af39a"
   end
 
   conflicts_with "kiek"


### PR DESCRIPTION
Make sure that [release **238041416**](https://github.com/wulf-data-engineering/kiek/releases/tag/untagged-b846fdef5753f5cd173c) has been published before merging!